### PR TITLE
Add Bilig WorkPaper MCP

### DIFF
--- a/data/bilig-workpaper-mcp/bilig-workpaper-mcp.md
+++ b/data/bilig-workpaper-mcp/bilig-workpaper-mcp.md
@@ -1,0 +1,10 @@
+## Overview
+
+Bilig WorkPaper MCP exposes `@bilig/headless` as a local-first stdio MCP server for spreadsheet-backed agent workflows.
+
+## Features
+
+- Formula-backed WorkPaper readback for computed workbook state
+- Verified input-cell edits with recalculated dependent values
+- JSON workbook persistence for service-side and coding-agent workflows
+- Public npm package with the `bilig-workpaper-mcp` stdio binary

--- a/data/bilig-workpaper-mcp/bilig-workpaper-mcp.yml
+++ b/data/bilig-workpaper-mcp/bilig-workpaper-mcp.yml
@@ -1,0 +1,16 @@
+name: Bilig WorkPaper MCP
+description: Headless spreadsheet WorkPaper MCP server for formula evaluation,
+  verified input edits, recalculated readback, and JSON workbook persistence in
+  Node.js agent workflows.
+source_url: https://github.com/proompteng/bilig
+category: Data Analysis & Exploration Mcp Servers
+tags:
+  - spreadsheet
+  - excel
+  - formula-engine
+  - nodejs
+  - ai-agents
+  - model-context-protocol
+  - workbook-automation
+featured: false
+updated_at: 2026-05-13 17:31


### PR DESCRIPTION
Adds Bilig WorkPaper MCP to the data source for the generated Awesome MCP Servers directory.

Bilig exposes @bilig/workpaper as a local-first stdio MCP server for spreadsheet WorkPaper reads, verified input edits, recalculated readback, and JSON workbook persistence in Node.js agent workflows.

Project: https://github.com/proompteng/bilig
Package: https://www.npmjs.com/package/@bilig/workpaper
