### PR TITLE
Add Xquik MCP server data

### DIFF
--- a/data/xquik-mcp-server/xquik-mcp-server.md
+++ b/data/xquik-mcp-server/xquik-mcp-server.md
@@ -33,3 +33,17 @@ https://xquik.com/openapi.json
 - Media extraction and webhook-driven automation
 - Developer workflows that need the same X data surface through REST, SDKs, and MCP
 
+## Category
+Social
+
+## Tags
+social-media, twitter, api-integration, data-extraction
+
+## Source
+[https://github.com/Xquik-dev/x-twitter-scraper](https://github.com/Xquik-dev/x-twitter-scraper)
+
+## License
+MIT License
+
+## Pricing
+Xquik API key required; see the Xquik docs for account details.

--- a/data/xquik-mcp-server/xquik-mcp-server.md
+++ b/data/xquik-mcp-server/xquik-mcp-server.md
@@ -1,0 +1,35 @@
+## Overview
+
+Xquik MCP Server provides remote MCP access to X/Twitter data and automation workflows through Xquik. It is designed for agents that need live X data without managing a local scraper process.
+
+## Capabilities
+
+- Search tweets with X query operators and filters
+- Look up tweets, users, trends, lists, and communities
+- Fetch user timelines, followers, and follow relationships
+- Download tweet media and read long-form X articles
+- Create account monitors and receive webhook events
+- Use write workflows such as posting, replies, likes, follows, and DMs when enabled
+
+## Integration
+
+The remote MCP endpoint is available at:
+
+```text
+https://xquik.com/mcp
+```
+
+Authentication uses an Xquik API key. The REST API schema is also published as OpenAPI at:
+
+```text
+https://xquik.com/openapi.json
+```
+
+## Use Cases
+
+- Social media research and OSINT workflows
+- Brand, account, and keyword monitoring
+- Agentic X/Twitter search and profile enrichment
+- Media extraction and webhook-driven automation
+- Developer workflows that need the same X data surface through REST, SDKs, and MCP
+

--- a/data/xquik-mcp-server/xquik-mcp-server.yml
+++ b/data/xquik-mcp-server/xquik-mcp-server.yml
@@ -1,0 +1,73 @@
+name: Xquik MCP Server
+description: Remote MCP server for X/Twitter data and automation workflows through Xquik, including tweet search, user lookup, trends, media, monitors, webhooks, and write workflows.
+source_url: https://github.com/Xquik-dev/x-twitter-scraper
+category: Social
+tags:
+  - social-media
+  - twitter
+  - api-integration
+  - data-extraction
+markdown: >-
+  ## Overview
+
+
+  Xquik MCP Server provides remote MCP access to X/Twitter data and automation
+  workflows through Xquik. It is designed for agents that need live X data
+  without managing a local scraper process.
+
+
+  ## Capabilities
+
+
+  - Search tweets with X query operators and filters
+
+  - Look up tweets, users, trends, lists, and communities
+
+  - Fetch user timelines, followers, and follow relationships
+
+  - Download tweet media and read long-form X articles
+
+  - Create account monitors and receive webhook events
+
+  - Use write workflows such as posting, replies, likes, follows, and DMs when
+  enabled
+
+
+  ## Integration
+
+
+  The remote MCP endpoint is available at:
+
+
+  ```text
+
+  https://xquik.com/mcp
+
+  ```
+
+
+  Authentication uses an Xquik API key. The REST API schema is also published
+  as OpenAPI at:
+
+
+  ```text
+
+  https://xquik.com/openapi.json
+
+  ```
+
+
+  ## Use Cases
+
+
+  - Social media research and OSINT workflows
+
+  - Brand, account, and keyword monitoring
+
+  - Agentic X/Twitter search and profile enrichment
+
+  - Media extraction and webhook-driven automation
+
+  - Developer workflows that need the same X data surface through REST, SDKs,
+  and MCP
+updated_at: 2026-05-17 20:35

--- a/data/xquik-mcp-server/xquik-mcp-server.yml
+++ b/data/xquik-mcp-server/xquik-mcp-server.yml
@@ -70,4 +70,34 @@ markdown: >-
 
   - Developer workflows that need the same X data surface through REST, SDKs,
   and MCP
+
+
+  ## Category
+
+
+  Social
+
+
+  ## Tags
+
+
+  social-media, twitter, api-integration, data-extraction
+
+
+  ## Source
+
+
+  [https://github.com/Xquik-dev/x-twitter-scraper](https://github.com/Xquik-dev/x-twitter-scraper)
+
+
+  ## License
+
+
+  MIT License
+
+
+  ## Pricing
+
+
+  Xquik API key required; see the Xquik docs for account details.
 updated_at: 2026-05-17 20:35


### PR DESCRIPTION
Adds Xquik MCP Server to the source data used by the awesome-mcp-servers list.

Duplicate checks:
- No Xquik entry exists in this data repo.
- Open and closed PRs and issues in this data repo have no Xquik submission.
- ever-works/awesome-mcp-servers has an open generated-list PR for Xquik, so this targets the data-source repo rather than opening another generated-list PR.

Validation:
- YAML parses with `yaml.safe_load`.
- Markdown and YAML link targets checked.
- `https://github.com/Xquik-dev/x-twitter-scraper` returned 200.
- `https://xquik.com/openapi.json` returned 200.
- `https://xquik.com/mcp` returned 401 as expected because the remote MCP endpoint requires an API key.
