### PR TITLE
Add UnifAPI MCP server

### DIFF
--- a/data/unifapi-mcp-server/unifapi-mcp-server.md
+++ b/data/unifapi-mcp-server/unifapi-mcp-server.md
@@ -1,0 +1,25 @@
+# UnifAPI MCP Server
+
+Hosted public-data MCP server for live social, search, scrape, news, creator research, and KOL pricing workflows.
+
+## Basic Info
+
+- **Name:** UnifAPI MCP Server
+- **Category:** Data Access Integration MCP Servers
+- **Brand:** UnifAPI
+- **Source URL:** https://github.com/unifapi-agent/unifapi-mcp-server
+- **MCP Endpoint:** `https://mcp.unifapi.com`
+- **Tags:** `public-data`, `social-media`, `web-search`, `web-scraping`, `news`, `creator-research`
+
+## Features
+
+- Live public data access for social, search, web scrape, and news workflows.
+- Creator research and KOL pricing workflows for marketing and partnership teams.
+- Hosted remote MCP endpoint with OAuth support.
+- Official MCP Registry listing for `com.unifapi/mcp`.
+
+## Setup & Configuration
+
+- Add `https://mcp.unifapi.com` as a remote MCP server in an MCP-compatible client.
+- Complete the OAuth flow when the client prompts for authorization.
+- API-key fallback is available for clients that cannot complete OAuth.

--- a/data/unifapi-mcp-server/unifapi-mcp-server.yml
+++ b/data/unifapi-mcp-server/unifapi-mcp-server.yml
@@ -1,0 +1,58 @@
+name: UnifAPI MCP Server
+description: Hosted public-data MCP server for social, search, scrape, news,
+  creator research, and KOL pricing workflows.
+source_url: https://github.com/unifapi-agent/unifapi-mcp-server
+category: data-access-integration-mcp-servers
+tags:
+  - public-data
+  - social-media
+  - web-search
+  - web-scraping
+  - news
+  - creator-research
+featured: false
+brand: UnifAPI
+brand_logo_url: https://unifapi.com/unif.png
+images: null
+markdown: >-
+  # UnifAPI MCP Server
+
+
+  Hosted public-data MCP server for live social, search, scrape, news, creator
+  research, and KOL pricing workflows.
+
+
+  ## Basic Info
+
+  - **Name:** UnifAPI MCP Server
+
+  - **Category:** Data Access Integration MCP Servers
+
+  - **Brand:** UnifAPI
+
+  - **Source URL:** https://github.com/unifapi-agent/unifapi-mcp-server
+
+  - **MCP Endpoint:** `https://mcp.unifapi.com`
+
+  - **Tags:** `public-data`, `social-media`, `web-search`, `web-scraping`, `news`, `creator-research`
+
+
+  ## Features
+
+  - Live public data access for social, search, web scrape, and news workflows.
+
+  - Creator research and KOL pricing workflows for marketing and partnership teams.
+
+  - Hosted remote MCP endpoint with OAuth support.
+
+  - Official MCP Registry listing for `com.unifapi/mcp`.
+
+
+  ## Setup & Configuration
+
+  - Add `https://mcp.unifapi.com` as a remote MCP server in an MCP-compatible client.
+
+  - Complete the OAuth flow when the client prompts for authorization.
+
+  - API-key fallback is available for clients that cannot complete OAuth.
+updated_at: 2026-05-31 00:00


### PR DESCRIPTION
## Summary

Adds UnifAPI MCP Server to the mcpserver.works data source.

## Details

- Adds a YAML metadata entry under `data/unifapi-mcp-server/`.
- Adds the matching Markdown description file.
- Includes the hosted MCP endpoint `https://mcp.unifapi.com`, repository URL, category, tags, and logo URL.

## Validation

- Parsed the YAML with Ruby `YAML.load_file`.
- Ran `git diff --check`.
- Verified the repository URL and logo URL return HTTP 200.
- Verified the MCP endpoint returns the expected unauthenticated OAuth challenge.
