### PR TITLE
Add Helium MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,4 @@
 
 This repository holds data used to generate [awesome-mcp-servers](https://github.com/ever-works/awesome-mcp-servers)
 
+- [Helium MCP](https://github.com/connerlambden/helium-mcp) — Real-time news with 37-dimension bias scoring, ML options pricing, and live market data. [Interactive demo](https://connerlambden.github.io/helium-news-explorer/) · [REST API](https://heliumtrades.com/mcp-page/)


### PR DESCRIPTION
Adds Helium MCP — 37-dim news bias scoring across 216 sources, ML options pricing, live market data. Interactive demos: https://connerlambden.github.io/helium-news-explorer/