### PR TITLE
Update MockHero MCP metadata

### DIFF
--- a/data/mockhero-mcp-server/mockhero-mcp-server.md
+++ b/data/mockhero-mcp-server/mockhero-mcp-server.md
@@ -1,5 +1,11 @@
 # MockHero MCP Server
 
-Generates realistic synthetic test data via MCP with 156 field types, 22 locales, relational data, sub-50ms responses. Free tier: 1,000 records/day.
+Agent-first MCP server for realistic synthetic test data. Agents can estimate usage, detect schemas from SQL or JSON, list field types and templates, create loginless Polar checkout, claim an API key, and generate JSON, CSV, or SQL test data through a hosted Streamable HTTP MCP endpoint.
 
-[https://github.com/mockherodev/mcp-server](https://github.com/mockherodev/mcp-server)
+[https://github.com/dinosaur24/mockhero](https://github.com/dinosaur24/mockhero)
+
+Remote MCP endpoint:
+
+```text
+https://mockhero.dev/mcp/agent
+```

--- a/data/mockhero-mcp-server/mockhero-mcp-server.yml
+++ b/data/mockhero-mcp-server/mockhero-mcp-server.yml
@@ -1,12 +1,12 @@
 name: MockHero MCP Server
-description: "Generates realistic synthetic test data via MCP with 156 field
-  types, 22 locales, relational data, sub-50ms responses. Free tier: 1,000
-  records/day."
-source_url: https://github.com/mockherodev/mcp-server
+description: "Agent-first MCP server for realistic synthetic test data with
+  usage estimates, schema detection, loginless Polar checkout, API key claim,
+  and JSON/CSV/SQL generation through a hosted Streamable HTTP endpoint."
+source_url: https://github.com/dinosaur24/mockhero
 category: Testing & Debugging Tools
 tags:
   - test-data
   - synthetic-data
-  - fast
+  - streamable-http
 featured: false
-updated_at: 2026-04-06 22:28
+updated_at: 2026-06-19 15:20


### PR DESCRIPTION
Updates MockHero to point to the active agent-first MCP implementation.\n\nChanges:\n- replaces the old GitHub URL with the current repository\n- removes outdated free-tier copy\n- documents the hosted Streamable HTTP MCP endpoint: https://mockhero.dev/mcp/agent\n- describes the current agent workflow: usage estimates, schema detection, loginless Polar checkout, API key claim, and JSON/CSV/SQL generation