### PR TITLE
Add NotFair — open-source Claude Code skills for SEO, Google Ads, and Meta Ads

### DIFF
--- a/data/notfair-mcp-skills/notfair-mcp-skills.md
+++ b/data/notfair-mcp-skills/notfair-mcp-skills.md
@@ -1,0 +1,29 @@
+## Overview
+
+NotFair is a collection of open-source Claude Code agent skills for marketing
+work. It connects to live ad and analytics data through MCP servers and runs
+directly in the Claude Code CLI.
+
+## Skill Areas
+
+- **[SEO](https://github.com/nowork-studio/NotFair/tree/main/seo/)** — site
+  analysis, keyword research, meta tags, schema markup, GEO optimization,
+  content writing (powered by Google Search Console MCP and Google Analytics
+  (GA4) MCP)
+- **[Google Ads](https://github.com/nowork-studio/NotFair/tree/main/google-ads/)** —
+  account audits, wasted-spend detection, search-term cleanup, keyword and
+  bid management (powered by Google Ads MCP)
+- **[Meta Ads](https://github.com/nowork-studio/NotFair/tree/main/meta-ads/)** —
+  ROAS analysis, creative fatigue detection, audience overlap (powered by
+  Meta Ads MCP)
+
+## MCP Integrations
+
+- Google Ads MCP
+- Meta Ads MCP
+- Google Search Console MCP
+- Google Analytics (GA4) MCP
+
+## License
+
+MIT

--- a/data/notfair-mcp-skills/notfair-mcp-skills.yml
+++ b/data/notfair-mcp-skills/notfair-mcp-skills.yml
@@ -1,0 +1,48 @@
+name: NotFair MCP Skills
+description: Open-source Claude Code skills for SEO, GEO, Google Ads, and Meta
+  Ads. Connects to live data through the Google Ads MCP, Meta Ads MCP, Google
+  Search Console MCP, and Google Analytics (GA4) MCP to run audits, keyword
+  research, wasted-spend detection, and creative-fatigue analysis directly from
+  the Claude Code CLI.
+source_url: https://github.com/nowork-studio/NotFair
+category: marketing-sales-mcp-servers
+tags:
+  - seo
+  - google-ads
+  - meta-ads
+  - marketing
+  - marketing-analytics
+  - open-source
+  - claude-code
+featured: false
+markdown: |-
+  ## Overview
+
+  NotFair is a collection of open-source Claude Code agent skills for marketing
+  work. It connects to live ad and analytics data through MCP servers and runs
+  directly in the Claude Code CLI.
+
+  ## Skill Areas
+
+  - **[SEO](https://github.com/nowork-studio/NotFair/tree/main/seo/)** — site
+    analysis, keyword research, meta tags, schema markup, GEO optimization,
+    content writing (powered by Google Search Console MCP and Google Analytics
+    (GA4) MCP)
+  - **[Google Ads](https://github.com/nowork-studio/NotFair/tree/main/google-ads/)** —
+    account audits, wasted-spend detection, search-term cleanup, keyword and
+    bid management (powered by Google Ads MCP)
+  - **[Meta Ads](https://github.com/nowork-studio/NotFair/tree/main/meta-ads/)** —
+    ROAS analysis, creative fatigue detection, audience overlap (powered by
+    Meta Ads MCP)
+
+  ## MCP Integrations
+
+  - Google Ads MCP
+  - Meta Ads MCP
+  - Google Search Console MCP
+  - Google Analytics (GA4) MCP
+
+  ## License
+
+  MIT
+updated_at: 2026-06-19 00:00


### PR DESCRIPTION
Thanks for maintaining this list. I'd like to add [NotFair](https://github.com/nowork-studio/NotFair), an open-source set of Claude Code agent skills for marketing work (~2.9k stars, MIT license).

NotFair fits here as a practical MCP-powered tool: it connects to the Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP to let users run ad audits, keyword research, wasted-spend detection, and creative-fatigue analysis directly from the Claude Code CLI.

The three skill areas are:
- **SEO** — keyword research, meta tags, schema markup, GEO optimization, content writing
- **Google Ads** — account audits, wasted-spend detection, search-term cleanup, bid management
- **Meta Ads** — ROAS analysis, creative fatigue, audience overlap

I've added `data/notfair-mcp-skills/notfair-mcp-skills.yml` and `.md` following the format of existing entries in this repo (category: `marketing-sales-mcp-servers`). Happy to reword the description, adjust the category, or trim the markdown if needed.